### PR TITLE
fix: correct Markdown link for GitHub username

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,4 +104,4 @@ This project is licensed under the **MIT License** - see the [LICENSE](LICENSE) 
 ![Works on my machine](https://github.com/user-attachments/assets/ec187cfa-001a-4ced-9f91-0bf0fb977f34)
 
 
-*Built with ❤️ by ![Das_F1sHy312](https://github.com/f1shyondrugs)*
+*Built with ❤️ by [Das_F1sHy312](https://github.com/f1shyondrugs)*


### PR DESCRIPTION
### **Description of Change**

This PR fixes the GitHub username link in the project footer. The previous implementation used image syntax (`![Alt](URL)`), which will render a corrupted image next to the clickable link.

* Replaced image-style Markdown with standard link syntax `[Text](URL)`

This improves readability and ensures the link works as intended across all Markdown-rendered views.

---

### **Release Notes**

**All platforms:** Fixed GitHub username link in the footer to use proper Markdown syntax, removing the corrupted image shown next to the link.