### PR TITLE
fix: windows-debugger not found when using interactive repl flag in packaged version

### DIFF
--- a/App/package-lock.json
+++ b/App/package-lock.json
@@ -35,6 +35,7 @@
         "simple-git": "^3.27.0",
         "tcp-port-used": "^1.0.2",
         "uuid": "^11.1.0",
+        "windows-debugger": "^1.1.2",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -47,8 +48,7 @@
         "electron-builder": "^24.9.1",
         "typescript": "^5.0.0",
         "vite": "^5.4.14",
-        "wait-on": "^7.2.0",
-        "windows-debugger": "^1.1.2"
+        "wait-on": "^7.2.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -8666,7 +8666,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/windows-debugger/-/windows-debugger-1.1.2.tgz",
       "integrity": "sha512-aedAMrWz1G87e2KmbK2zcpcvKx9NlRXVDLlclofA5NIl7G4bQNI6co30YuoiSbDbrnGts1t3SMYEenaFTRVZBQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {

--- a/App/package.json
+++ b/App/package.json
@@ -41,6 +41,7 @@
     "simple-git": "^3.27.0",
     "tcp-port-used": "^1.0.2",
     "uuid": "^11.1.0",
+    "windows-debugger": "^1.1.2",
     "zustand": "^5.0.3"
   },
   "devDependencies": {
@@ -53,8 +54,7 @@
     "electron-builder": "^24.9.1",
     "typescript": "^5.0.0",
     "vite": "^5.4.14",
-    "wait-on": "^7.2.0",
-    "windows-debugger": "^1.1.2"
+    "wait-on": "^7.2.0"
   },
   "proxy": "http://localhost:1234",
   "build": {


### PR DESCRIPTION
### **Description of Change**

This PR moves `windows-debugger` from a development dependency to a runtime dependency to make it available after packaging.

### **Release Notes**

Notes: no-notes