### PR TITLE
[codex] Fix README stars badge rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/PointerIDE/Pointer/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/PointerIDE/Pointer?style=for-the-badge&logo=github&color=111111"></a>
+  <a href="https://github.com/PointerIDE/Pointer/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/PointerIDE/Pointer.svg?style=for-the-badge&logo=github&color=111111&label=stars&cacheSeconds=3600"></a>
   <a href="https://github.com/PointerIDE/Pointer/network/members"><img alt="GitHub forks" src="https://img.shields.io/github/forks/PointerIDE/Pointer?style=for-the-badge&logo=github&color=111111"></a>
   <a href="https://github.com/PointerIDE/Pointer/issues"><img alt="GitHub issues" src="https://img.shields.io/github/issues/PointerIDE/Pointer?style=for-the-badge&logo=github&color=111111"></a>
   <a href="https://github.com/PointerIDE/Pointer/commits/main"><img alt="Last commit" src="https://img.shields.io/github/last-commit/PointerIDE/Pointer?style=for-the-badge&logo=git&color=111111"></a>


### PR DESCRIPTION
## Summary

- Updates the README stars badge to a distinct `.svg` Shields URL.
- Adds an explicit `label=stars` and `cacheSeconds=3600` so GitHub does not reuse the old invalid Camo image.

## Validation

- Confirmed the new Shields endpoint renders the current star count (`26`) instead of `INVALID`.
- Documentation-only change, so no build or TypeScript checks were run.