### PR TITLE
[codex] Fix release parallel rebuild exit handling

### DIFF
--- a/scripts/build-pointer-release.ps1
+++ b/scripts/build-pointer-release.ps1
@@ -254,6 +254,16 @@ function Invoke-Npm {
 	Invoke-ProcessLogged -Name $Name -FilePath $NpmCmd -Arguments $Arguments -WorkingDirectory $WorkingDirectory
 }
 
+function ConvertTo-CmdArgument {
+	param([Parameter(Mandatory = $true)][string]$Argument)
+
+	if ($Argument -notmatch '[\s"]') {
+		return $Argument
+	}
+
+	return '"' + ($Argument -replace '"', '\"') + '"'
+}
+
 function Start-NpmProcessLogged {
 	param(
 		[Parameter(Mandatory = $true)][string]$Name,
@@ -271,13 +281,16 @@ function Start-NpmProcessLogged {
 
 	Remove-Item -LiteralPath $stdoutPath, $stderrPath, $logPath -Force -ErrorAction SilentlyContinue
 
-	$process = Start-Process -FilePath $NpmCmd `
-		-ArgumentList $Arguments `
-		-WorkingDirectory $WorkingDirectory `
-		-RedirectStandardOutput $stdoutPath `
-		-RedirectStandardError $stderrPath `
-		-PassThru `
-		-NoNewWindow
+	$argumentText = ($Arguments | ForEach-Object { ConvertTo-CmdArgument $_ }) -join ' '
+	$command = "`"$NpmCmd`" $argumentText > `"$stdoutPath`" 2> `"$stderrPath`""
+	$startInfo = New-Object System.Diagnostics.ProcessStartInfo
+	$startInfo.FileName = $env:ComSpec
+	$startInfo.Arguments = "/d /s /c `"$command`""
+	$startInfo.WorkingDirectory = $WorkingDirectory
+	$startInfo.UseShellExecute = $false
+	$startInfo.CreateNoWindow = $true
+
+	$process = [System.Diagnostics.Process]::Start($startInfo)
 
 	return [PSCustomObject]@{
 		Name = $Name


### PR DESCRIPTION
## Summary
- replaces the parallel npm rebuild process launcher with a cmd.exe-backed process so completed processes expose a reliable ExitCode
- keeps stdout/stderr logging behavior unchanged

## Testing
- PowerShell parser check for scripts/build-pointer-release.ps1
- git diff --check

## Context
The main release run failed after a successful native package rebuild because Start-Process returned an empty ExitCode when used without -Wait in the parallel wrapper.