### PR TITLE
[codex] Install build deps before Electron download

### DIFF
--- a/scripts/build-pointer-release.ps1
+++ b/scripts/build-pointer-release.ps1
@@ -589,6 +589,7 @@ function Install-Dependencies {
 		Write-Host "Skipped, marker exists: $nativeMarker"
 	}
 
+	Install-NpmDirectory -RelativeDirectory 'build'
 	Invoke-Node -Name 'download-electron' -Arguments @('build/lib/electron.ts')
 
 	$dirs = @(


### PR DESCRIPTION
## Summary
- installs/validates build/ dependencies before running build/lib/electron.ts
- fixes release failure where download-electron could not import ternary-stream from build/node_modules

## Testing
- PowerShell parser check for scripts/build-pointer-release.ps1
- git diff --check

No local release build was run.